### PR TITLE
Add transmission delays and change stop bits to 2

### DIFF
--- a/telnetserver/telnetserver.ino
+++ b/telnetserver/telnetserver.ino
@@ -15,6 +15,11 @@ WiFiClient serverClient;
 WiFiManager wifiManager;
 
 #define BAUD_RATE 9600
+// Transmit delays. Those are necessary for the bit-banging serial IO
+// implementation of the KIM-1 to keep up.
+//
+#define CHAR_DELAY 20
+#define LINE_DELAY 100
 
 const char* update_path = "/firmware";
 const char* update_username = "admin";
@@ -23,7 +28,9 @@ int RESET_PIN = 0; // = GPIO0 on nodeMCU
 
 void setup()
 {
-  Serial.begin(BAUD_RATE, SERIAL_8N1);
+  // SERIAL_8N1 seems to work too, but the KIM-1 specs are two stop bits
+  //
+  Serial.begin(BAUD_RATE, SERIAL_8N2);
   Serial.setRxBufferSize(1024); // requires ESP8266 >= 2.4.0 https://github.com/esp8266/Arduino/releases/tag/2.4.0-rc1
 
   delay(5000); // BOOT WAIT
@@ -55,15 +62,17 @@ void AcceptConnection()
   if (serverClient && serverClient.connected()) 
     serverClient.stop();
   serverClient = server.available();
-  // IAC WILL SUPPRESS-GO-AHEAD
+
+  // IAC DO SUPPRESS-GO-AHEAD
   serverClient.write(255);
   serverClient.write(253);
   serverClient.write(3);
-  // I WILL ECHO
+  // IAC WILL ECHO
   serverClient.write(255);
   serverClient.write(251);
   serverClient.write(1);
-  serverClient.write("Connected\n");
+
+  serverClient.write("Connected\r\n");
 }
 
 void ManageConnected()
@@ -72,8 +81,19 @@ void ManageConnected()
   if (rxlen > 0)
   {
     uint8_t sbuf[rxlen];
+    uint8_t *s = sbuf;
+
     serverClient.readBytes(sbuf, rxlen);
-    Serial.write(sbuf, rxlen);
+    while (rxlen--)
+    {
+      Serial.write(*s);
+
+      if (*s == '\n')
+        delay(LINE_DELAY);
+      else
+        delay(CHAR_DELAY);
+      ++s;
+    }
   }
   
   size_t txlen = Serial.available();


### PR DESCRIPTION
The bit banged serial IO implementation of the KIM-1 needs transmission delays between characters to keep up with the terminal emulator. Those are not normally needed for regular typing, as a human operator is not fast enough, but are necessary for file transmission or when the terminal emulator sends back control characters to the KIM in response to VT100 commands, for example.

Values that I have configured in serial connections and work for me are 20ms delay between characters and 100ms between lines.

Also, the settings of the serial transmission for the KIM-1 are 8bit, no parity and ***two*** stop bits. Usually just one stop bit works, but I'd rather stick with the official specs.